### PR TITLE
Add new methods to consent class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ typings/
 
 # development time ignore rules
 usageTracking
+dist/

--- a/src/common/consent.test.ts
+++ b/src/common/consent.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from 'vitest'
+import WebConsent from '../web/webConsent'
+
+describe('Consent', () => {
+  test('should return the provided question answer false', async () => {
+    let webConsent: WebConsent = new WebConsent()
+    expect(await webConsent.provideConsentQuestionAnswer('no')).toBeFalsy()
+    expect(await webConsent.provideConsentQuestionAnswer('No')).toBeFalsy()
+    expect(await webConsent.provideConsentQuestionAnswer('fAlSe')).toBeFalsy()
+    expect(await webConsent.provideConsentQuestionAnswer('1')).toBeFalsy()
+    expect(await webConsent.provideConsentQuestionAnswer('0')).toBeFalsy()
+    expect(await webConsent.provideConsentQuestionAnswer('')).toBeFalsy()
+    expect(await webConsent.provideConsentQuestionAnswer(undefined)).toBeFalsy()
+  })
+
+  test('should return the provided question answer yes', async () => {
+    let webConsent: WebConsent = new WebConsent()
+    expect(await webConsent.provideConsentQuestionAnswer('yes')).toBeTruthy()
+    expect(await webConsent.provideConsentQuestionAnswer('YeS')).toBeTruthy()
+    expect(await webConsent.provideConsentQuestionAnswer('y')).toBeTruthy()
+    expect(await webConsent.provideConsentQuestionAnswer('Y')).toBeTruthy()
+  })
+})

--- a/src/common/consent.ts
+++ b/src/common/consent.ts
@@ -6,4 +6,16 @@ export default abstract class Consent {
 
   abstract askConsentConfirm(): Promise<boolean>
   abstract askConsentQuestion(): Promise<boolean>
+
+  provideConsentConfirmAnswer(consent: string = Consent.message): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      consent?.toUpperCase() === 'Y' || consent?.toUpperCase() === 'YES' ? resolve(true) : reject(false)
+    })
+  }
+
+  provideConsentQuestionAnswer(consent: string = Consent.message): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      resolve(consent?.toUpperCase() === 'Y' || consent?.toUpperCase() === 'YES' ? true : false)
+    })
+  }
 }

--- a/src/common/tracker.ts
+++ b/src/common/tracker.ts
@@ -25,6 +25,14 @@ export default abstract class Tracker {
     return await this.requestConsent(this.consent.askConsentConfirm.bind(this.consent), consentArguments)
   }
 
+  public async provideConsentQuestionAnswer(consentArguments: ConsentArguments): Promise<boolean> {
+    return await this.requestConsent(this.consent.provideConsentQuestionAnswer.bind(this.consent), consentArguments)
+  }
+
+  public async provideConsentConfirmAnswer(consentArguments: ConsentArguments): Promise<boolean> {
+    return await this.requestConsent(this.consent.provideConsentConfirmAnswer.bind(this.consent), consentArguments)
+  }
+
   async trackUsage(trackUsageArguments: TrackUsageArguments): Promise<void> {
     if (this.storage.isConsentGranted()) {
       this.storage.setLatestUsage(trackUsageArguments.toolName, trackUsageArguments.featureName)

--- a/src/web/webConsent.ts
+++ b/src/web/webConsent.ts
@@ -1,6 +1,6 @@
 import Consent from '../common/consent'
 
-export default class WebConsent implements Consent {
+export default class WebConsent extends Consent {
   #dialogId = 'automated-usage-tracking-tool-dialog'
   #dialogContentId = `${this.#dialogId}-content`
   #dialogFooterId = `${this.#dialogId}-footer`


### PR DESCRIPTION
Add new methods provideConsentConfirmAnswer and provideConsentQuestionAnswer to consent class
These methods will get the consent answer as argument and will be useful to support custom consent collecting implementations.